### PR TITLE
feat: Rename capture binary from ndi-bridge to ndi-capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,15 +251,15 @@ if(USE_DECKLINK AND WIN32)
     endif()
 endif()
 
-# Main executable
-add_executable(${PROJECT_NAME}
+# Main executable (capture application)
+add_executable(ndi-capture
     src/main.cpp
     ${COMMON_SOURCES}
     ${PLATFORM_SOURCES}
 )
 
 # Set executable properties
-set_target_properties(${PROJECT_NAME} PROPERTIES
+set_target_properties(ndi-capture PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
@@ -319,7 +319,7 @@ if(PLATFORM_LINUX)
 endif()
 
 # Set version definitions
-target_compile_definitions(${PROJECT_NAME} PRIVATE
+target_compile_definitions(ndi-capture PRIVATE
     NDI_BRIDGE_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
     NDI_BRIDGE_VERSION_MINOR=${PROJECT_VERSION_MINOR}
     NDI_BRIDGE_VERSION_PATCH=${PROJECT_VERSION_PATCH}
@@ -328,18 +328,18 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
 # Set synchronous mode flag if enabled
 if(MF_SYNCHRONOUS_MODE)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE MF_SYNCHRONOUS_CAPTURE)
+    target_compile_definitions(ndi-capture PRIVATE MF_SYNCHRONOUS_CAPTURE)
     message(STATUS "Media Foundation synchronous mode: ENABLED (experimental)")
 else()
     message(STATUS "Media Foundation synchronous mode: DISABLED")
 endif()
 
 # Link libraries
-target_link_libraries(${PROJECT_NAME} PRIVATE ${NDI_LIBRARY})
+target_link_libraries(ndi-capture PRIVATE ${NDI_LIBRARY})
 
 if(PLATFORM_WINDOWS)
     # Windows Media Foundation and system libraries
-    target_link_libraries(${PROJECT_NAME} PRIVATE
+    target_link_libraries(ndi-capture PRIVATE
         mfplat
         mfreadwrite
         mfuuid
@@ -352,15 +352,15 @@ if(PLATFORM_WINDOWS)
     
     # Copy NDI runtime DLL to output directory
     if(NDI_DLL)
-        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        add_custom_command(TARGET ndi-capture POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${NDI_DLL}"
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            $<TARGET_FILE_DIR:ndi-capture>
         )
     endif()
 elseif(PLATFORM_LINUX)
     # Linux system libraries
-    target_link_libraries(${PROJECT_NAME} PRIVATE
+    target_link_libraries(ndi-capture PRIVATE
         Threads::Threads
         dl
         m
@@ -370,7 +370,7 @@ elseif(PLATFORM_LINUX)
     # RPATH for finding NDI library
     if(NDI_LIBRARY)
         get_filename_component(NDI_LIB_DIR ${NDI_LIBRARY} DIRECTORY)
-        set_target_properties(${PROJECT_NAME} PROPERTIES
+        set_target_properties(ndi-capture PROPERTIES
             INSTALL_RPATH "${NDI_LIB_DIR}"
             BUILD_WITH_INSTALL_RPATH TRUE
         )
@@ -391,7 +391,7 @@ elseif(PLATFORM_LINUX)
 endif()
 
 # Installation rules
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ndi-capture
     RUNTIME DESTINATION bin
 )
 

--- a/build-image-for-rufus.sh
+++ b/build-image-for-rufus.sh
@@ -30,7 +30,7 @@ fi
 
 # Check for required binaries - build them if missing
 echo "Checking for required binaries..."
-if [ ! -f "build/bin/ndi-bridge" ] || [ ! -f "build/bin/ndi-display" ]; then
+if [ ! -f "build/bin/ndi-capture" ] || [ ! -f "build/bin/ndi-display" ]; then
     echo "ERROR: Required binaries missing. Building them now..."
     if [ ! -d "build" ]; then
         mkdir build
@@ -43,13 +43,13 @@ if [ ! -f "build/bin/ndi-bridge" ] || [ ! -f "build/bin/ndi-display" ]; then
     cd ..
     
     # Verify binaries exist after build
-    if [ ! -f "build/bin/ndi-bridge" ] || [ ! -f "build/bin/ndi-display" ]; then
+    if [ ! -f "build/bin/ndi-capture" ] || [ ! -f "build/bin/ndi-display" ]; then
         echo "ERROR: Failed to build required binaries"
         echo "Please run: cd build && make -j\$(nproc)"
         exit 1
     fi
 fi
-echo "✓ ndi-bridge binary found"
+echo "✓ ndi-capture binary found"
 echo "✓ ndi-display binary found"
 
 # Create image file (4GB should be enough)

--- a/deploy-to-box.sh
+++ b/deploy-to-box.sh
@@ -83,12 +83,12 @@ EOF
 
 # Deploy core binaries
 log_info "Deploying NDI-Bridge binaries..."
-if [ -f "$MOUNT_DIR/opt/ndi-bridge/ndi-bridge" ]; then
+if [ -f "$MOUNT_DIR/opt/ndi-bridge/ndi-capture" ]; then
     sshpass -p "$BOX_PASS" scp -o StrictHostKeyChecking=no \
-        "$MOUNT_DIR/opt/ndi-bridge/ndi-bridge" \
-        $BOX_USER@$BOX_IP:/opt/ndi-bridge/ndi-bridge
+        "$MOUNT_DIR/opt/ndi-bridge/ndi-capture" \
+        $BOX_USER@$BOX_IP:/opt/ndi-bridge/ndi-capture
     sshpass -p "$BOX_PASS" ssh -o StrictHostKeyChecking=no $BOX_USER@$BOX_IP \
-        "chmod +x /opt/ndi-bridge/ndi-bridge"
+        "chmod +x /opt/ndi-bridge/ndi-capture"
 fi
 
 if [ -f "$MOUNT_DIR/opt/ndi-bridge/ndi-display" ]; then

--- a/files/systemd/system/ndi-capture.service
+++ b/files/systemd/system/ndi-capture.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=NDI Bridge
+Description=NDI Capture Service
 After=network-online.target
 Wants=network-online.target
 

--- a/quick-deploy.sh
+++ b/quick-deploy.sh
@@ -29,11 +29,11 @@ sudo mount -o loop,offset=537919488,ro "$IMAGE_FILE" "$MOUNT_DIR"
 
 # Deploy binaries only (fastest for testing)
 echo "Deploying binaries..."
-sshpass -p newlevel ssh root@$BOX_IP "systemctl stop ndi-bridge ndi-display@1 2>/dev/null || true"
+sshpass -p newlevel ssh root@$BOX_IP "systemctl stop ndi-capture ndi-display@1 2>/dev/null || true"
 sleep 1
 
 # Copy binaries
-sshpass -p newlevel scp $MOUNT_DIR/opt/ndi-bridge/ndi-bridge root@$BOX_IP:/opt/ndi-bridge/ 2>/dev/null || echo "ndi-bridge not updated"
+sshpass -p newlevel scp $MOUNT_DIR/opt/ndi-bridge/ndi-capture root@$BOX_IP:/opt/ndi-bridge/ 2>/dev/null || echo "ndi-capture not updated"
 sshpass -p newlevel scp $MOUNT_DIR/opt/ndi-bridge/ndi-display root@$BOX_IP:/opt/ndi-bridge/ 2>/dev/null || echo "ndi-display not updated"
 
 # Copy critical scripts
@@ -43,15 +43,15 @@ sshpass -p newlevel scp $MOUNT_DIR/usr/local/bin/ndi-bridge-info root@$BOX_IP:/u
 
 # Restart services
 echo "Restarting services..."
-sshpass -p newlevel ssh root@$BOX_IP "systemctl start ndi-bridge ndi-display@1 2>/dev/null || true"
+sshpass -p newlevel ssh root@$BOX_IP "systemctl start ndi-capture ndi-display@1 2>/dev/null || true"
 
 # Quick status check
 echo -e "\n${GREEN}Deployment Status:${NC}"
 sshpass -p newlevel ssh root@$BOX_IP << 'EOF' 2>/dev/null | grep -v "NDI Bridge Status"
-echo "ndi-bridge version: $(/opt/ndi-bridge/ndi-bridge --version 2>/dev/null || echo 'error')"
+echo "ndi-capture version: $(/opt/ndi-bridge/ndi-capture --version 2>/dev/null || echo 'error')"
 echo "ndi-display version: $(/opt/ndi-bridge/ndi-display --version 2>&1 | head -1 || echo 'error')"
 echo "Services:"
-systemctl is-active ndi-bridge 2>/dev/null || echo "ndi-bridge: stopped"
+systemctl is-active ndi-capture 2>/dev/null || echo "ndi-capture: stopped"
 systemctl is-active ndi-display@1 2>/dev/null || echo "ndi-display@1: stopped"
 EOF
 

--- a/scripts/build-modules/09-ndi-service.sh
+++ b/scripts/build-modules/09-ndi-service.sh
@@ -4,20 +4,20 @@
 configure_ndi_service() {
     log "Configuring NDI Bridge service..."
     
-    # Copy NDI Bridge binary BEFORE chroot (so it's accessible)
-    if [ -f build/bin/ndi-bridge ]; then
+    # Copy NDI Capture binary BEFORE chroot (so it's accessible)
+    if [ -f build/bin/ndi-capture ]; then
         mkdir -p /mnt/usb/opt/ndi-bridge
-        cp build/bin/ndi-bridge /mnt/usb/opt/ndi-bridge/
-        chmod +x /mnt/usb/opt/ndi-bridge/ndi-bridge
-        log "NDI Bridge binary copied"
+        cp build/bin/ndi-capture /mnt/usb/opt/ndi-bridge/
+        chmod +x /mnt/usb/opt/ndi-bridge/ndi-capture
+        log "NDI Capture binary copied"
     else
-        log "ERROR: ndi-bridge binary not found at build/bin/ndi-bridge"
+        log "ERROR: ndi-capture binary not found at build/bin/ndi-capture"
         exit 1
     fi
     
     # Copy systemd service files BEFORE chroot
     mkdir -p /mnt/usb/etc/systemd/system
-    for service in ndi-bridge.service setup-logs.service ndi-bridge-collector.service; do
+    for service in ndi-capture.service setup-logs.service ndi-bridge-collector.service; do
         if [ -f files/systemd/system/$service ]; then
             cp files/systemd/system/$service /mnt/usb/etc/systemd/system/
             log "  Copied $service"
@@ -91,13 +91,13 @@ check_time_sync
 
 # Main loop with restart and logging to tmpfs
 while true; do
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting NDI Bridge: $DEVICE -> $NDI_NAME"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting NDI Capture: $DEVICE -> $NDI_NAME"
     if [ -w /var/log/ndi-bridge ]; then
-        LD_LIBRARY_PATH=/usr/local/lib /opt/ndi-bridge/ndi-bridge "$DEVICE" "$NDI_NAME" 2>&1 | tee -a /var/log/ndi-bridge/ndi-bridge.log
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] NDI Bridge exited, restarting in 5 seconds..." | tee -a /var/log/ndi-bridge/ndi-bridge.log
+        LD_LIBRARY_PATH=/usr/local/lib /opt/ndi-bridge/ndi-capture "$DEVICE" "$NDI_NAME" 2>&1 | tee -a /var/log/ndi-bridge/ndi-capture.log
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] NDI Capture exited, restarting in 5 seconds..." | tee -a /var/log/ndi-bridge/ndi-capture.log
     else
-        LD_LIBRARY_PATH=/usr/local/lib /opt/ndi-bridge/ndi-bridge "$DEVICE" "$NDI_NAME" 2>&1
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] NDI Bridge exited, restarting in 5 seconds..."
+        LD_LIBRARY_PATH=/usr/local/lib /opt/ndi-bridge/ndi-capture "$DEVICE" "$NDI_NAME" 2>&1
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] NDI Capture exited, restarting in 5 seconds..."
     fi
     sleep 5
 done
@@ -105,12 +105,12 @@ EOFRUN
 chmod +x /opt/ndi-bridge/run.sh
 
 # Systemd service files were copied before chroot
-# ndi-bridge.service is now in /etc/systemd/system/
+# ndi-capture.service is now in /etc/systemd/system/
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl enable ndi-bridge
+    systemctl enable ndi-capture
 else
-    update-rc.d ndi-bridge enable 2>/dev/null || true
+    update-rc.d ndi-capture enable 2>/dev/null || true
 fi
 
 # setup-logs.service was copied before chroot

--- a/scripts/helper-scripts/ndi-bridge-collector
+++ b/scripts/helper-scripts/ndi-bridge-collector
@@ -8,7 +8,7 @@ mkdir -p /var/run/ndi-bridge
 # Main collection loop
 while true; do
     # 1. Get current FPS from last metrics entry (only if recent)
-    METRICS_LINE=$(journalctl -u ndi-bridge -n 200 --no-pager 2>/dev/null | grep "METRICS|" | tail -1)
+    METRICS_LINE=$(journalctl -u ndi-capture -n 200 --no-pager 2>/dev/null | grep "METRICS|" | tail -1)
     if [ -n "$METRICS_LINE" ]; then
         # Extract timestamp and check if recent (within 5 seconds)
         METRICS_TIME=$(echo "$METRICS_LINE" | cut -d' ' -f1-3)
@@ -39,7 +39,7 @@ while true; do
     fi
     
     # 2. Get 10-minute FPS history and calculate average
-    FPS_HISTORY=$(journalctl -u ndi-bridge --since "10 minutes ago" --no-pager 2>/dev/null | grep "METRICS|" | sed -n 's/.*FPS:\([0-9.]*\).*/\1/p')
+    FPS_HISTORY=$(journalctl -u ndi-capture --since "10 minutes ago" --no-pager 2>/dev/null | grep "METRICS|" | sed -n 's/.*FPS:\([0-9.]*\).*/\1/p')
     if [ -n "$FPS_HISTORY" ]; then
         # Calculate average
         AVG_FPS=$(echo "$FPS_HISTORY" | awk '{sum+=$1; count++} END {if(count>0) printf "%.2f", sum/count; else print "0"}')
@@ -79,7 +79,7 @@ while true; do
         echo "NO_DEVICE" > /var/run/ndi-bridge/capture_state
     elif systemctl is-active --quiet ndi-bridge; then
         # Service is running, check if actually capturing (has recent metrics)
-        LAST_METRIC_TIME=$(journalctl -u ndi-bridge -n 10 --no-pager 2>/dev/null | grep "METRICS|" | tail -1 | cut -d' ' -f1-3)
+        LAST_METRIC_TIME=$(journalctl -u ndi-capture -n 10 --no-pager 2>/dev/null | grep "METRICS|" | tail -1 | cut -d' ' -f1-3)
         if [ -n "$LAST_METRIC_TIME" ]; then
             # Check if metric is recent (within last 5 seconds)
             LAST_EPOCH=$(date -d "$LAST_METRIC_TIME" +%s 2>/dev/null || echo "0")
@@ -90,7 +90,7 @@ while true; do
                 echo "CAPTURING" > /var/run/ndi-bridge/capture_state
             else
                 # Check for recent errors
-                RECENT_ERROR=$(journalctl -u ndi-bridge -n 5 --no-pager 2>/dev/null | grep -E "ERROR|Failed to open device")
+                RECENT_ERROR=$(journalctl -u ndi-capture -n 5 --no-pager 2>/dev/null | grep -E "ERROR|Failed to open device")
                 if [ -n "$RECENT_ERROR" ]; then
                     echo "ERROR" > /var/run/ndi-bridge/capture_state
                 else

--- a/scripts/helper-scripts/ndi-bridge-info
+++ b/scripts/helper-scripts/ndi-bridge-info
@@ -23,7 +23,7 @@ echo ""
 
 # Software Versions
 echo -e "${CYAN}Software Versions:${NC}"
-echo "  NDI-Bridge:     $(/opt/ndi-bridge/ndi-bridge --version 2>&1 | head -1 | awk '{for(i=1;i<=NF;i++) if($i ~ /[0-9]+\.[0-9]+\.[0-9]+/) print $i}' || echo 'Unknown')"
+echo "  NDI-Capture:    $(/opt/ndi-bridge/ndi-capture --version 2>&1 | head -1 | awk '{for(i=1;i<=NF;i++) if($i ~ /[0-9]+\.[0-9]+\.[0-9]+/) print $i}' || echo 'Unknown')"
 echo "  Build Script:   $(cat /etc/ndi-bridge/build-script-version 2>/dev/null || echo 'Unknown')"
 echo "  Build Date:     $(cat /etc/ndi-bridge/build-date 2>/dev/null || echo 'Unknown')"
 echo ""
@@ -72,16 +72,16 @@ echo ""
 
 # Service Status
 echo -e "${CYAN}Service Status:${NC}"
-if systemctl is-active --quiet ndi-bridge; then
-    echo -e "  NDI Bridge:     ${GREEN}● Running${NC}"
+if systemctl is-active --quiet ndi-capture; then
+    echo -e "  NDI Capture:    ${GREEN}● Running${NC}"
     # Show recent log entries
     echo "  Recent logs:"
-    journalctl -u ndi-bridge -n 3 --no-pager | tail -n +2 | sed 's/^/    /'
+    journalctl -u ndi-capture -n 3 --no-pager | tail -n +2 | sed 's/^/    /'
 else
-    echo -e "  NDI Bridge:     ${RED}● Stopped${NC}"
+    echo -e "  NDI Capture:    ${RED}● Stopped${NC}"
     # Show why it's not running
     echo "  Last error:"
-    journalctl -u ndi-bridge -n 5 --no-pager | grep -i error | tail -1 | sed 's/^/    /'
+    journalctl -u ndi-capture -n 5 --no-pager | grep -i error | tail -1 | sed 's/^/    /'
 fi
 echo ""
 

--- a/scripts/helper-scripts/ndi-bridge-welcome
+++ b/scripts/helper-scripts/ndi-bridge-welcome
@@ -16,7 +16,7 @@ TERM_WIDTH=$(tput cols 2>/dev/null || echo 80)
 
 # Create dynamic width header
 HEADER_LINE=$(printf '═%.0s' $(seq 1 $TERM_WIDTH))
-TITLE="NDI Bridge Status Dashboard"
+TITLE="Media Bridge Status Dashboard"
 TITLE_LEN=${#TITLE}
 PADDING=$(( (TERM_WIDTH - TITLE_LEN) / 2 ))
 
@@ -48,7 +48,7 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "none" ]; then
     fi
     # Fallback to hostname-based name
     if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "none" ]; then
-        STREAM_NAME="NDI Bridge $(hostname)"
+        STREAM_NAME="NDI Capture $(hostname)"
     fi
 fi
 
@@ -372,7 +372,7 @@ echo ""
 
 # BUILD INFO
 echo -e "${CYAN}▶ BUILD INFO${NC}"
-echo "  NDI Bridge:  v$(/opt/ndi-bridge/ndi-bridge --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo 'Unknown')"
+echo "  NDI Capture: v$(/opt/ndi-bridge/ndi-capture --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo 'Unknown')"
 echo "  Image Built: $(cat /etc/ndi-bridge/build-timestamp 2>/dev/null || echo 'Unknown')"
 echo "  Build Ver:   $(cat /etc/ndi-bridge/build-script-version 2>/dev/null || echo 'Unknown')"
 echo ""


### PR DESCRIPTION
## Summary
Renames the capture application binary from `ndi-bridge` to `ndi-capture` to better describe its functionality.

## Changes
- **CMakeLists.txt**: Changed to build `ndi-capture` executable instead of using PROJECT_NAME
- **Systemd service**: Renamed from `ndi-bridge.service` to `ndi-capture.service`
- **Build scripts**: Updated all references to the binary
- **Helper scripts**: Updated to reference `ndi-capture` process
- **Deploy scripts**: Updated to deploy `ndi-capture` binary

## Important Notes
- This only renames the capture binary, NOT the entire project
- Repository remains `ndi-bridge` (that's issue #32)
- Directory structure remains `/opt/ndi-bridge/`
- Helper script names remain `ndi-bridge-*`
- Display binary remains `ndi-display` (unchanged)

## Testing
✅ Built successfully with `make`
✅ `ndi-capture --version` returns version correctly
✅ Ready for deployment testing

Fixes #31