### PR TITLE
Fix build process for NDI SDK 6.2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,49 @@ Fixes #25"
 
 **Build takes 10-15 minutes. Image output: `ndi-bridge.img` (8GB)**
 
+## Clean Repository Build Process
+
+**Building USB Image from Freshly Cloned Repository:**
+
+1. **Clone and enter repository:**
+```bash
+git clone https://github.com/yourusername/ndi-bridge.git
+cd ndi-bridge
+```
+
+2. **Setup build environment (installs dependencies and NDI SDK):**
+```bash
+./setup-build-environment.sh
+```
+This will:
+- Install all build dependencies (cmake, libv4l-dev, etc.)
+- Download and install NDI SDK v6 to project directory
+- Verify the installation
+
+3. **Build application binaries:**
+```bash
+./build.sh
+```
+This creates ndi-capture and ndi-display binaries in `build/bin/`
+
+4. **Increment version number:**
+```bash
+# Edit scripts/build-modules/00-variables.sh
+# Change BUILD_SCRIPT_VERSION (e.g., "1.9.5" → "1.9.6")
+```
+
+5. **Build USB image:**
+```bash
+sudo ./build-image-for-rufus.sh > build.log 2>&1 &
+tail -f build.log  # Monitor progress
+```
+Build takes 10-15 minutes. Output: `ndi-bridge.img` (8GB)
+
+**Common Issues & Solutions:**
+- `losetup package not found` → Fixed: use util-linux package instead
+- `NDI SDK directory not found` → Fixed: installer extracts to current dir, not home
+- `libndi.so.6.2.0 not found` → Fixed: NDI SDK v6 has libndi.so.6.2.1
+
 ## Quick Commands
 
 ### Application Build (AUTO-APPROVED)

--- a/scripts/build-modules/00-variables.sh
+++ b/scripts/build-modules/00-variables.sh
@@ -3,7 +3,7 @@
 # This module defines all global variables used throughout the build process
 
 # Build Script Version - Auto-incremented with each build
-BUILD_SCRIPT_VERSION="1.9.4"
+BUILD_SCRIPT_VERSION="1.9.5"
 BUILD_SCRIPT_DATE="2025-08-29"
 
 # Build timestamp - Generated at build time (local timezone)

--- a/scripts/build-ndi-usb-modular.sh
+++ b/scripts/build-ndi-usb-modular.sh
@@ -49,9 +49,9 @@ copy_ndi_files() {
     
     # Copy NDI libraries
     mkdir -p /mnt/usb/usr/local/lib
-    cp "$NDI_SDK_PATH/lib/x86_64-linux-gnu/libndi.so.6.2.0" /mnt/usb/usr/local/lib/
+    cp "$NDI_SDK_PATH/lib/x86_64-linux-gnu/libndi.so.6.2.1" /mnt/usb/usr/local/lib/
     cd /mnt/usb/usr/local/lib
-    ln -s libndi.so.6.2.0 libndi.so.6
+    ln -s libndi.so.6.2.1 libndi.so.6
     ln -s libndi.so.6 libndi.so
     cd - > /dev/null
 }

--- a/setup-build-environment.sh
+++ b/setup-build-environment.sh
@@ -139,7 +139,7 @@ install_build_deps() {
         "e2fsprogs"
         "debootstrap"
         "kpartx"
-        "losetup"
+        "util-linux"
         "grub2-common"
         "grub-pc-bin"
         "grub-efi-amd64-bin"
@@ -198,15 +198,28 @@ install_ndi_sdk() {
     
     # Run installer non-interactively
     log_info "Installing NDI SDK..."
-    echo "y" | ./"$INSTALLER" > /dev/null
+    # The installer extracts to current directory, not home directory
+    yes | ./"$INSTALLER" 2>&1 | grep -v "^$"
     
     # Move SDK to project directory
     cd - > /dev/null
-    if [ -d ~/NDI\ SDK\ for\ Linux ]; then
-        mv ~/NDI\ SDK\ for\ Linux ./ 2>/dev/null || cp -r ~/NDI\ SDK\ for\ Linux ./ 
+    
+    # Look for the SDK in temp directory first (where installer extracted it)
+    if [ -d "$TEMP_DIR/NDI SDK for Linux" ]; then
+        log_info "Moving NDI SDK from temp directory to project root..."
+        mv "$TEMP_DIR/NDI SDK for Linux" "./" || cp -r "$TEMP_DIR/NDI SDK for Linux" "./"
+        log_info "NDI SDK installed to project directory"
+    elif [ -d "$TEMP_DIR/NDI_SDK_Linux" ]; then
+        log_info "Moving NDI SDK from temp directory to project root..."
+        mv "$TEMP_DIR/NDI_SDK_Linux" "./NDI SDK for Linux" || cp -r "$TEMP_DIR/NDI_SDK_Linux" "./NDI SDK for Linux"
+        log_info "NDI SDK installed to project directory"
+    elif [ -d ~/NDI\ SDK\ for\ Linux ]; then
+        log_info "Moving NDI SDK from home directory to project root..."
+        mv ~/NDI\ SDK\ for\ Linux ./ 2>/dev/null || cp -r ~/NDI\ SDK\ for\ Linux ./
         log_info "NDI SDK installed to project directory"
     else
-        log_error "NDI SDK installation failed - directory not found"
+        log_error "NDI SDK installation failed - directory not found in expected locations"
+        log_error "Checked: $TEMP_DIR/NDI SDK for Linux, $TEMP_DIR/NDI_SDK_Linux, ~/NDI SDK for Linux"
         exit 1
     fi
     


### PR DESCRIPTION
## Summary
- Fixed build failures when building from freshly cloned repository
- Updated NDI SDK library version from 6.2.0 to 6.2.1
- Improved setup script reliability

## Changes
- **setup-build-environment.sh**: Fixed NDI SDK installation to check multiple directories
- **setup-build-environment.sh**: Replaced incorrect 'losetup' package with 'util-linux'
- **scripts/build-ndi-usb-modular.sh**: Updated NDI library version to 6.2.1
- **CLAUDE.md**: Added comprehensive clean build documentation
- **00-variables.sh**: Incremented build version to 1.9.5

## Test Plan
- [x] Clone fresh repository
- [x] Run setup-build-environment.sh
- [x] Build binaries with ./build.sh
- [ ] Create USB image with build-image-for-rufus.sh
- [ ] Test on physical hardware

🤖 Generated with [Claude Code](https://claude.ai/code)