### PR TITLE
Fix boot test service expectations (issue #77)

### DIFF
--- a/tests/system/test_boot_sequence.py
+++ b/tests/system/test_boot_sequence.py
@@ -48,12 +48,12 @@ def test_complete_boot_sequence(host):
 
 
 def test_auto_start_enabled_services(host):
-    """Test that all required services are enabled for auto-start."""
+    """Test that all required systemd services are enabled for auto-start."""
     required_services = [
-        "ndi-capture",
-        "media-bridge-welcome",
-        "nginx",
-        "systemd-networkd"
+        "ndi-capture",      # Video capture service
+        "nginx",            # Web interface
+        "systemd-networkd", # Network configuration
+        "ssh"               # Remote access
     ]
     
     for service_name in required_services:


### PR DESCRIPTION
## Summary
Fixes failing boot test by correcting service expectations to match actual system configuration.

## Problem
The test `test_auto_start_enabled_services` was checking for `media-bridge-welcome` as a systemd service, but it doesn't exist. The welcome screen runs via `.profile` on TTY2, not as a service.

## Solution
Updated the required services list to include only actual systemd services that should be enabled:
- ✅ `ndi-capture` - Video capture service
- ✅ `nginx` - Web interface
- ✅ `systemd-networkd` - Network configuration  
- ✅ `ssh` - Remote access (added as critical service)

## Test Results
Tested on device 10.77.8.110 - all boot sequence tests pass:
```
✅ test_complete_boot_sequence
✅ test_auto_start_enabled_services
✅ test_runtime_directories_created
```

## Related Issues
Fixes #77

🤖 Generated with [Claude Code](https://claude.ai/code)