### PR TITLE
Fix web interface index test path (issue #71)

### DIFF
--- a/tests/component/web/test_web_interface.py
+++ b/tests/component/web/test_web_interface.py
@@ -15,9 +15,10 @@ def test_web_server_responds_to_http(host):
 
 
 def test_web_interface_index_exists(host):
-    """Test that index.html exists."""
-    index_file = host.file("/var/www/html/index.html")
-    assert index_file.exists, "Web interface index.html not found"
+    """Test that web interface index.html exists."""
+    # Check the actual Media Bridge web frontend location
+    index_file = host.file("/opt/media-bridge-web/frontend/index.html")
+    assert index_file.exists, "Web interface index.html not found at /opt/media-bridge-web/frontend/"
 
 
 def test_api_endpoint_info_responds(host):


### PR DESCRIPTION
## Summary
Fixes failing web interface test by updating the path to check the correct location where the Media Bridge web interface is actually installed.

## Problem
Test was looking for `/var/www/html/index.html` (default nginx location) but the actual web interface is at `/opt/media-bridge-web/frontend/index.html`.

## Solution  
Updated the test to check the correct path as configured in `/etc/nginx/sites-available/media-bridge`:
```nginx
root /opt/media-bridge-web/frontend;
```

## Test Results
Tested on device 10.77.8.110 - all web interface tests pass:
```
✅ test_web_server_responds_to_http
✅ test_web_interface_index_exists
✅ test_api_endpoint_info_responds
✅ test_web_terminal_wetty_installed
✅ test_web_authentication_configured
✅ test_nginx_config_syntax_valid
✅ test_web_root_directory_exists
✅ test_nginx_error_log_exists
✅ test_nginx_access_log_exists
```

## Related Issues
Fixes #71

🤖 Generated with [Claude Code](https://claude.ai/code)