### PR TITLE
Remove non-existent welcome service test (issue #70)

### DIFF
--- a/tests/component/helpers/test_helper_scripts.py
+++ b/tests/component/helpers/test_helper_scripts.py
@@ -59,12 +59,6 @@ def test_ndi_bridge_welcome_script_exists(host):
     assert script.exists, "media-bridge-welcome script not found"
 
 
-def test_ndi_bridge_welcome_service_enabled(host):
-    """Test that media-bridge-welcome service is enabled."""
-    service = host.service("media-bridge-welcome")
-    assert service.is_enabled, "media-bridge-welcome service not enabled"
-
-
 def test_ndi_bridge_collector_script_exists(host):
     """Test that media-bridge-collector script exists."""
     script = host.file("/usr/local/bin/media-bridge-collector")


### PR DESCRIPTION
## Summary
Removes a test that was checking for a systemd service that doesn't exist.

## Problem
The test `test_ndi_bridge_welcome_service_enabled` was expecting `media-bridge-welcome.service` to be enabled, but this service doesn't exist. The welcome screen is displayed via `.profile` on TTY2, not through a systemd service.

## Solution
Removed the service test entirely. The welcome script itself is still tested by `test_ndi_bridge_welcome_script_exists` which correctly verifies that `/usr/local/bin/media-bridge-welcome` exists.

## Test Results
Tested on device 10.77.8.110 - all helper script tests pass:
```
✅ test_ndi_bridge_info_script_exists
✅ test_ndi_bridge_info_script_executable
✅ test_ndi_bridge_info_runs_successfully
✅ test_ndi_bridge_logs_script_exists
✅ test_ndi_bridge_logs_script_executable
✅ test_ndi_bridge_set_name_script_exists
⏭️ test_ndi_bridge_restart_script_exists (skipped - optional)
✅ test_ndi_bridge_welcome_script_exists
✅ test_ndi_bridge_collector_script_exists
✅ test_ndi_bridge_collector_service_enabled
✅ test_ndi_bridge_collector_service_running
✅ test_helper_scripts_in_path
```

## Related Issues
Fixes #70

🤖 Generated with [Claude Code](https://claude.ai/code)