### PR TITLE
Add PipeWire 1.4.7 upgrade module

### DIFF
--- a/scripts/build-modules/00-variables.sh
+++ b/scripts/build-modules/00-variables.sh
@@ -3,8 +3,8 @@
 # This module defines all global variables used throughout the build process
 
 # Build Script Version - Auto-incremented with each build
-BUILD_SCRIPT_VERSION="2.2.6"
-BUILD_SCRIPT_DATE="2025-09-04"
+BUILD_SCRIPT_VERSION="2.2.7"
+BUILD_SCRIPT_DATE="2025-09-10"
 
 # Build timestamp - Generated at build time (local timezone)
 BUILD_TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S %Z')"

--- a/scripts/build-modules/08a-pipewire-upgrade.sh
+++ b/scripts/build-modules/08a-pipewire-upgrade.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Module 08a: PipeWire 1.4.7 Upgrade
+# Upgrades PipeWire to version 1.4.7 using Rob Savoury's PPA for better Chrome audio isolation
+# This module adds to the chroot configuration script that runs after base system installation
+
+configure_pipewire_upgrade() {
+    log "MODULE 08a: PipeWire 1.4.7 Upgrade - Configuring for chroot"
+    
+    # Append PipeWire upgrade to the chroot configuration script
+    cat >> /mnt/usb/tmp/configure-system.sh << 'PIPEWIRE_UPGRADE_EOF'
+
+echo ""
+echo "============================"
+echo "MODULE 08a: PipeWire 1.4.7 Upgrade"
+echo "============================"
+
+# Install software-properties-common for add-apt-repository
+echo "Installing prerequisites for PipeWire upgrade..."
+apt-get install -y -qq software-properties-common gnupg 2>&1 | head -10
+
+# Add Rob Savoury's PPA for PipeWire 1.4.7
+echo "Adding PipeWire 1.4.7 PPA..."
+add-apt-repository -y ppa:savoury1/pipewire 2>&1 | head -10
+
+# Update package lists
+echo "Updating package lists..."
+apt-get update -qq 2>&1 | head -10
+
+# Install specific version of PipeWire 1.4.7
+echo "Installing PipeWire 1.4.7..."
+apt-get install -y -qq \
+    pipewire=1.4.7-0ubuntu1~24.04.sav0 \
+    pipewire-pulse=1.4.7-0ubuntu1~24.04.sav0 \
+    pipewire-alsa=1.4.7-0ubuntu1~24.04.sav0 \
+    libpipewire-0.3-0t64=1.4.7-0ubuntu1~24.04.sav0 \
+    libpipewire-0.3-modules=1.4.7-0ubuntu1~24.04.sav0 \
+    libspa-0.2-modules=1.4.7-0ubuntu1~24.04.sav0 \
+    pipewire-bin=1.4.7-0ubuntu1~24.04.sav0 \
+    gstreamer1.0-pipewire=1.4.7-0ubuntu1~24.04.sav0 2>&1 | head -20
+
+# Install WirePlumber (session manager)
+echo "Installing WirePlumber..."
+apt-get install -y -qq wireplumber libwireplumber-0.5-0 2>&1 | head -20
+
+# Install PulseAudio utilities for compatibility
+echo "Installing PulseAudio utilities..."
+apt-get install -y -qq pulseaudio-utils 2>&1 | head -20
+
+# Verify PipeWire version
+echo "Verifying PipeWire installation..."
+INSTALLED_VERSION=$(pipewire --version 2>&1 | grep -oP 'pipewire \K[0-9.]+' || echo "unknown")
+EXPECTED_VERSION="1.4.7"
+
+if [[ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]]; then
+    echo "WARNING: PipeWire version mismatch!"
+    echo "Expected: $EXPECTED_VERSION"
+    echo "Installed: $INSTALLED_VERSION"
+    # Continue anyway as fallback will handle it
+else
+    echo "✓ PipeWire $INSTALLED_VERSION installed successfully"
+fi
+
+# Check for pw-container (available in 1.4.7)
+if command -v pw-container &> /dev/null; then
+    echo "✓ pw-container tool is available (for Chrome isolation)"
+else
+    echo "⚠ pw-container not found - Chrome isolation features may be limited"
+fi
+
+# Pin PipeWire packages to prevent accidental upgrades
+echo "Pinning PipeWire packages to version 1.4.7..."
+cat > /etc/apt/preferences.d/pipewire-pin << 'EOF'
+Package: pipewire pipewire-* libpipewire-* libspa-*
+Pin: version 1.4.7-0ubuntu1~24.04.sav0
+Pin-Priority: 1001
+
+Package: wireplumber libwireplumber-*
+Pin: version 0.5.*
+Pin-Priority: 900
+EOF
+
+echo "✓ PipeWire packages pinned to prevent upgrades"
+
+# Configure systemd overrides for PipeWire system service
+echo "Configuring PipeWire system service resource limits..."
+mkdir -p /etc/systemd/system/pipewire-system.service.d
+
+# Create override file for file descriptor limits
+cat > /etc/systemd/system/pipewire-system.service.d/override.conf << 'LIMIT_EOF'
+# PipeWire System Service Override
+# Increases file descriptor limits for multimedia testing
+# Fixes "Too many open files" errors during extensive test runs
+
+[Service]
+# Increase file descriptor limits for PipeWire system service
+# Default limit (1024) is insufficient for multimedia operations with many clients
+LimitNOFILE=32768
+LimitNOFILESoft=16384
+
+# Additional resource limits for stable operation
+LimitNPROC=32768
+LimitMEMLOCK=infinity
+
+# Restart policy for reliability during testing
+Restart=on-failure
+RestartSec=5s
+LIMIT_EOF
+
+echo "✓ PipeWire system service resource limits configured"
+
+# Create marker file for other modules
+touch /tmp/pipewire-1.4.7-installed
+
+echo "Module 08a: PipeWire 1.4.7 upgrade completed successfully"
+echo ""
+
+PIPEWIRE_UPGRADE_EOF
+
+    log "Module 08a: PipeWire upgrade configuration added to chroot script"
+}
+
+# The function will be called by the main build script at the right time

--- a/scripts/build-ndi-usb-modular.sh
+++ b/scripts/build-ndi-usb-modular.sh
@@ -18,6 +18,7 @@ source "$SCRIPT_DIR/build-modules/05-debootstrap.sh"
 source "$SCRIPT_DIR/build-modules/06-system-config.sh"
 source "$SCRIPT_DIR/build-modules/07-base-setup.sh"
 source "$SCRIPT_DIR/build-modules/08-network.sh"
+source "$SCRIPT_DIR/build-modules/08a-pipewire-upgrade.sh"
 source "$SCRIPT_DIR/build-modules/09-ndi-capture-service.sh"
 source "$SCRIPT_DIR/build-modules/10-ndi-display-service.sh"
 source "$SCRIPT_DIR/build-modules/11-intercom-chrome.sh"
@@ -74,6 +75,7 @@ assemble_configuration() {
     configure_system
     setup_base_system
     configure_network
+    configure_pipewire_upgrade
     configure_time_sync
     configure_ndi_service
     configure_ndi_display_service

--- a/tests/component/audio/test_pipewire_version.py
+++ b/tests/component/audio/test_pipewire_version.py
@@ -1,0 +1,72 @@
+"""
+Tests for PipeWire 1.4.7 version verification.
+
+Ensures that PipeWire 1.4.7 from Rob Savoury's PPA is correctly installed.
+"""
+
+import pytest
+
+
+def test_pipewire_version_is_1_4_7(host):
+    """Test that PipeWire version is 1.4.7."""
+    result = host.run("pipewire --version")
+    assert result.rc == 0, "Failed to get PipeWire version"
+    # Check for version 1.4.7 in output
+    output_lines = result.stdout.strip().split('\n')
+    version_found = False
+    for line in output_lines:
+        if "1.4.7" in line:
+            version_found = True
+            break
+    assert version_found, f"PipeWire version is not 1.4.7. Output: {result.stdout}"
+
+
+def test_pw_container_tool_available(host):
+    """Test that pw-container tool is available (PipeWire 1.4.7 feature)."""
+    result = host.run("which pw-container")
+    assert result.rc == 0, "pw-container tool not found (requires PipeWire 1.4.7)"
+    assert "/usr/bin/pw-container" in result.stdout, f"pw-container in unexpected location: {result.stdout}"
+
+
+def test_pipewire_packages_version(host):
+    """Test that all PipeWire packages are version 1.4.7 from Savoury PPA."""
+    result = host.run("dpkg -l | grep pipewire | awk '{print $2, $3}'")
+    assert result.rc == 0, "Failed to list PipeWire packages"
+    
+    packages_checked = 0
+    for line in result.stdout.strip().split('\n'):
+        if line and 'pipewire' in line:
+            parts = line.split()
+            if len(parts) >= 2:
+                package, version = parts[0], parts[1]
+                assert "1.4.7" in version, f"Package {package} is not version 1.4.7: {version}"
+                assert "sav0" in version, f"Package {package} not from Savoury PPA: {version}"
+                packages_checked += 1
+    
+    assert packages_checked > 0, "No PipeWire packages found to verify"
+
+
+def test_pipewire_version_pinning(host):
+    """Test that PipeWire packages are pinned to prevent downgrades."""
+    pin_file = host.file("/etc/apt/preferences.d/pipewire-pin")
+    assert pin_file.exists, "PipeWire version pinning file not found"
+    
+    content = pin_file.content_string
+    assert "1.4.7-0ubuntu1~24.04.sav0" in content, "Version pin not set to 1.4.7"
+    assert "Pin-Priority: 1001" in content, "Pin priority not high enough"
+
+
+@pytest.mark.critical
+def test_pipewire_upgrade_from_default(host):
+    """Test that PipeWire was upgraded from Ubuntu's default 1.0.5."""
+    # Check that we're not running the default Ubuntu version
+    result = host.run("apt-cache policy pipewire | grep -E 'Installed|Candidate'")
+    assert result.rc == 0
+    
+    # Verify installed version is from PPA
+    assert "1.4.7" in result.stdout, "PipeWire not upgraded to 1.4.7"
+    assert "sav0" in result.stdout, "PipeWire not from Savoury PPA"
+    
+    # Make sure default Ubuntu version is not installed
+    assert "1.0.5" not in result.stdout or "Installed" not in result.stdout.split("1.0.5")[0], \
+        "Ubuntu's default PipeWire 1.0.5 is still installed"


### PR DESCRIPTION
## Summary
- Adds PipeWire 1.4.7 upgrade module that was missing from main branch
- Fixes discrepancy between documentation (claims 1.4.7) and implementation (installs 1.0.5)
- Critical for Chrome audio isolation features to work properly

## Changes
- Added `scripts/build-modules/08a-pipewire-upgrade.sh` from fix-chrome-audio-isolation branch
- Updated `scripts/build-ndi-usb-modular.sh` to source and call the new module
- PipeWire upgrades from Ubuntu 24.04's default 1.0.5 to 1.4.7 via Rob Savoury's PPA

## Why This Was Missed
In PRs #119 and #120, we focused on documentation and deployment infrastructure only, intentionally avoiding the 8 build module changes to keep PRs focused. This critical piece was overlooked.

## Testing
Will build USB image after merge to verify PipeWire 1.4.7 is correctly installed.

Related to #34 (Chrome audio isolation issues)